### PR TITLE
Add modeling utilities with tests

### DIFF
--- a/src/modeling.py
+++ b/src/modeling.py
@@ -1,0 +1,46 @@
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import accuracy_score
+from sklearn.preprocessing import StandardScaler
+
+
+def create_feature_target(df: pd.DataFrame, features=None):
+    """Return feature matrix X and target y for classification.
+
+    If ``features`` is None, all columns except ``flank_wear`` are used as
+    features. The target ``y`` is binarized based on the median of the
+    ``flank_wear`` column if it is not already integer typed.
+    """
+    if features is None:
+        features = [c for c in df.columns if c != "flank_wear"]
+    X = df[features]
+    y = df["flank_wear"]
+    if not pd.api.types.is_integer_dtype(y) and not pd.api.types.is_bool_dtype(y):
+        y = (y > y.median()).astype(int)
+    return X, y
+
+
+def scale_features(X: pd.DataFrame) -> pd.DataFrame:
+    """Scale numeric columns using :class:`StandardScaler`."""
+    scaler = StandardScaler()
+    scaled = scaler.fit_transform(X)
+    return pd.DataFrame(scaled, columns=X.columns, index=X.index)
+
+
+def train_random_forest(X: pd.DataFrame, y: pd.Series, test_size: float = 0.2,
+                         random_state: int = 0):
+    """Split ``X``/``y``, train a :class:`RandomForestClassifier` and return
+    the fitted model along with the held‑out test arrays."""
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=test_size, random_state=random_state
+    )
+    clf = RandomForestClassifier(n_estimators=50, random_state=random_state)
+    clf.fit(X_train, y_train)
+    return clf, X_test, y_test
+
+
+def evaluate_accuracy(model, X_test: pd.DataFrame, y_test: pd.Series) -> float:
+    """Return the classification accuracy for ``model`` on ``X_test``."""
+    preds = model.predict(X_test)
+    return accuracy_score(y_test, preds)

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,6 +1,10 @@
 import os
+import sys
 import pandas as pd
 import pytest
+
+# Ensure the src package is importable when running `pytest` directly
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from src.data_loader import load_vicomtech_data
 

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import pandas as pd
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.modeling import create_feature_target, train_random_forest, evaluate_accuracy
+
+
+def test_create_feature_target_shape():
+    df = pd.DataFrame({
+        'feat1': [1, 2, 3],
+        'feat2': [4, 5, 6],
+        'flank_wear': [0.1, 0.2, 0.3]
+    })
+    X, y = create_feature_target(df, features=['feat1', 'feat2'])
+    assert X.shape == (3, 2)
+    assert y.shape == (3,)
+
+
+def test_random_forest_accuracy():
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(200, 2))
+    y = (X[:, 0] + X[:, 1] > 0).astype(int)
+    df = pd.DataFrame(X, columns=['f1', 'f2'])
+    df['flank_wear'] = y
+    X_feat, y_target = create_feature_target(df, features=['f1', 'f2'])
+    model, X_test, y_test = train_random_forest(X_feat, y_target, random_state=0)
+    acc = evaluate_accuracy(model, X_test, y_test)
+    assert acc > 0.8


### PR DESCRIPTION
## Summary
- ensure test suite can import `src` when running pytest directly
- add `modeling` module with feature prep and model training helpers
- test new feature engineering utilities and modeling accuracy

## Testing
- `python3 -m pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686fe9c90c8c83269ff4ebce79ae3ad6